### PR TITLE
support libvirtd graphics tablet for mouse input

### DIFF
--- a/config/boot/loader.conf
+++ b/config/boot/loader.conf
@@ -11,6 +11,7 @@ loader_menu_title_align="left"
 ums_load="YES"
 aio_load="YES"
 snd_uaudio_load="YES"
+utouch_load="YES"
 
 hint.pcm.0.eq="1"
 hint.pcm.1.eq="1"

--- a/pkg.list
+++ b/pkg.list
@@ -43,6 +43,7 @@ mail/thunderbird
 math/galculator
 misc/mc
 misc/qt5ct
+misc/utouch-kmod
 multimedia/simplescreenrecorder
 multimedia/vlc
 multimedia/x264
@@ -100,6 +101,7 @@ vietnamese/hunspell
 www/firefox-esr
 www/lynx
 x11-drivers/xf86-input-libinput
+x11-drivers/xf86-input-evdev
 x11-drivers/xf86-video-ati
 x11-drivers/xf86-video-intel
 x11-drivers/xf86-video-nv


### PR DESCRIPTION
Referencing https://forums.freebsd.org/threads/qemu-kvm-freebsd-guest-running-x-and-a-working-mouse.82460/ one can get the mouse to work in libvirt qemu guests via installing `11-drivers/xf86-input-evdev` and `misc/utouch-kmod`.

Unfortunately I wasn't able to produce a usable nomadbsd image.  I didn't invest too much time into troubleshooting yet, so that's my next step.

![image](https://user-images.githubusercontent.com/3893828/213947269-e50ada85-8237-4bab-8607-edcd054ab84f.png)


P.S. the steps to create a libvirtd qemu image for testing: `qemu-img create -f qcow2 nomadbsd.qcow2 20G` (create the image), `qemu-img dd -f raw -O qcow2 if=nomadbsd-131R-b383beda.amd64.ufs.img of=nomadbsd2.qcow2` (write the raw image into the beginning of the qcow2 image).